### PR TITLE
[FEAT] 로그인/회원가입 폼 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,10 +29,8 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       'react/jsx-no-target-blank': 'off',
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'no-undef': 'off',
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
 ];

--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>⛰️Jeju month</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",
     "react-router": "^7.1.3",
-    "react-router-dom": "^7.1.3"
+    "react-router-dom": "^7.1.3",
+    "tailwindcss-preset-px-to-rem": "^1.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@tanstack/react-query": "^5.64.1",
     "@tanstack/react-query-devtools": "^5.64.1",
     "antd": "^5.23.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
 import './App.css';
+import { RouterProvider } from 'react-router-dom';
+import router from './routes/router';
 
 function App() {
   console.log('hello world');
-  return <main>hello world</main>;
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/components/common/Button/index.jsx
+++ b/src/components/common/Button/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './style.css';
+
+const bgColorVariants = {
+  orange: 'bg-orange-300 hover:bg-orange-400 text-white', // TODO : primary로 변경
+};
+
+const roundedVariants = {
+  base: 'rounded-4', // antd default
+  full: 'rounded-full',
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+};
+
+const Button = ({
+  type,
+  label,
+  onClick,
+  isDisabled = false,
+  rounded = 'base',
+  color = 'orange',
+}) => {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={isDisabled}
+      className={`btn ${bgColorVariants[color]}
+        ${roundedVariants[rounded]} text-14 `}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default Button;
+
+Button.propTypes = {
+  type: PropTypes.oneOf(['submit', 'button', 'reset']).isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  isDisabled: PropTypes.bool,
+  rounded: PropTypes.string,
+  color: PropTypes.string,
+};

--- a/src/components/common/Button/style.css
+++ b/src/components/common/Button/style.css
@@ -1,0 +1,3 @@
+.btn {
+  @apply py-7 px-5 w-full;
+}

--- a/src/components/common/Form/index.jsx
+++ b/src/components/common/Form/index.jsx
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import { useForm } from 'react-hook-form';
+import FormInput from '../FormInput';
+import Button from '../Button';
+const Form = ({
+  onSubmit,
+  submitButtonText,
+  inputs,
+  headerText,
+  guideText,
+  children,
+  watchTarget,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+  } = useForm({
+    mode: 'onChange',
+  });
+
+  const formAdaptor = ({ register, name, input }) => {
+    const { attributes, validate } = input;
+    return { ...register(name, validate), ...attributes };
+  };
+
+  const formInputs = inputs(getValues);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="mb-14">
+        <div className="mb-40">
+          {headerText && <h2 className="text-26 font-bold mb-18">{headerText}</h2>}
+          {guideText && <p className="text-12 font-semibold">{guideText}</p>}
+        </div>
+
+        <div>
+          {Object.entries(formInputs).map(([name, input]) => (
+            <FormInput
+              key={name}
+              errorMessage={errors[name]?.message?.toString() || ''}
+              props={formAdaptor({ register, name, input })}
+              label={input.options.label}
+              inputGuide={input.options.inputGuide}
+            />
+          ))}
+        </div>
+
+        <Button type="submit" label={submitButtonText} color="orange" />
+      </div>
+      {children}
+    </form>
+  );
+};
+
+Form.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  submitButtonText: PropTypes.string.isRequired,
+  inputs: PropTypes.func.isRequired,
+  headerText: PropTypes.string,
+  guideText: PropTypes.string,
+  children: PropTypes.node,
+  watchTarget: PropTypes.string,
+};
+export default Form;

--- a/src/components/common/FormInput/index.jsx
+++ b/src/components/common/FormInput/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+//import { Input, Form } from 'antd';
+
+const FormInput = ({ props, errorMessage, label, inputGuide }) => {
+  return (
+    <div className="w-full flex flex-col gap-5 mb-20">
+      {label && <label className="text-11 font-bold mb-4">{label}</label>}
+
+      <input
+        {...props}
+        className="w-full border-solid border-[1px] rounded-3 border-slate-300 text-10 px-13 py-11 h-36 focus-within:border-orange-400 focus-within:outline focus-within:outline-orange-100 focus-within:outline-2 transition ease-in-out delay-150 "
+      />
+      <div className="flex flex-row gap-2 items-center">
+        {inputGuide && <span className="text-8 font-semibold text-slate-600">{inputGuide}</span>}
+        {errorMessage && (
+          <span className="text-8 text-red-400 ">
+            <em>{errorMessage}</em>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FormInput;
+
+FormInput.propTypes = {
+  props: PropTypes.object.isRequired,
+  errorMessage: PropTypes.string,
+  label: PropTypes.string,
+  inputGuide: PropTypes.string,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -14,8 +14,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family:
+    'Pretendard Variable',
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/src/layouts/AuthLayout.jsx
+++ b/src/layouts/AuthLayout.jsx
@@ -1,11 +1,15 @@
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 const AuthLayout = () => {
   return (
-    <div>
-      AuthLayout
-      <Outlet />
+    <div className="w-screen h-screen">
+      <div className="w-full max-w-962  mx-auto flex flex-col h-full">
+        <div className="text-red-600 h-70">헤더가 이곳에 표시됩니다.</div>
+        <div className="w-314 mx-auto flex-1">
+          <Outlet />
+        </div>
+        <div className="text-red-600 h-70 ">푸터가 이곳에 표시됩니다.</div>
+      </div>
     </div>
   );
 };

--- a/src/layouts/AuthLayout.jsx
+++ b/src/layouts/AuthLayout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const AuthLayout = () => {
+  return (
+    <div>
+      AuthLayout
+      <Outlet />
+    </div>
+  );
+};
+
+export default AuthLayout;

--- a/src/layouts/DefaultLayout.jsx
+++ b/src/layouts/DefaultLayout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const DefaultLayout = () => {
+  return (
+    <div>
+      기본 레이아웃 입니다.
+      <Outlet />
+    </div>
+  );
+};
+
+export default DefaultLayout;

--- a/src/layouts/DefaultLayout.jsx
+++ b/src/layouts/DefaultLayout.jsx
@@ -1,10 +1,8 @@
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 const DefaultLayout = () => {
   return (
     <div>
-      기본 레이아웃 입니다.
       <Outlet />
     </div>
   );

--- a/src/pages/Homepage/index.jsx
+++ b/src/pages/Homepage/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const HomePage = () => {
+  return <div>HomePage</div>;
+};
+
+export default HomePage;

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
-
 // 로그인
 const SigninPage = () => {
-  return <div>SigninPage</div>;
+  return <div className="bg-slate-300 h-full">SigninPage</div>;
 };
 
 export default SigninPage;

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// 로그인
+const SigninPage = () => {
+  return <div>SigninPage</div>;
+};
+
+export default SigninPage;

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -1,6 +1,76 @@
+import Form from '../../components/common/Form';
+import { Link } from 'react-router-dom';
+import { Button } from 'antd';
+
 // 로그인
 const SigninPage = () => {
-  return <div className="bg-slate-300 h-full">SigninPage</div>;
+  const onSubmit = data => {
+    console.log('do something');
+  };
+
+  const SigninInputs = getValues => {
+    return {
+      email: {
+        attributes: {
+          placeholder: '이메일을 입력해주세요',
+          type: 'email',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '이메일은 필수 입력항목입니다.',
+          },
+          pattern: {
+            value: /[a-z0-9]+@[a-z]+\.[a-z]{2,3}/,
+            message: '올바른 이메일 형식이 아닙니다.',
+          },
+        },
+        options: {
+          inputGuide: '@를 포함한 이메일 주소',
+          label: '이메일',
+        },
+      },
+      password: {
+        attributes: {
+          placeholder: '비밀번호를 입력해주세요.',
+          type: 'password',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '비밀번호는 필수 입력항목입니다.',
+          },
+          pattern: {
+            value:
+              /^(?=.*[a-zA-Z])(?=.*\d|.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$|^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$|^(?=.*\d)(?=.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$/,
+            message: '올바른 비밀번호 형식이 아닙니다.',
+          },
+        },
+        options: {
+          inputGuide: '영문 대·소문자/숫자.특수문자 중 2가지 이상 조합, 8~16글자',
+          label: '비밀번호',
+        },
+      },
+    };
+  };
+  const formProps = {
+    onSubmit: onSubmit,
+    headerText: '로그인',
+    guideText: '제주 한 달 살기 서비스를 이용하기 위해 로그인해주세요.',
+    submitButtonText: '로그인 하기',
+    inputs: SigninInputs,
+  };
+  return (
+    <div className="w-full h-full flex justify-center items-center">
+      <div className="w-full">
+        <Form {...formProps}>
+          <Button className="w-full">
+            <Link to="/auth/signup">회원가입</Link>
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
 };
 
 export default SigninPage;

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// 회원가입
+const SignupPage = () => {
+  return <div>SignupPage</div>;
+};
+
+export default SignupPage;

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -1,8 +1,123 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from 'antd';
+import Form from '../../components/common/Form';
 
-// 회원가입
 const SignupPage = () => {
-  return <div>SignupPage</div>;
+  const onSubmit = data => {
+    console.log('do something');
+  };
+
+  console.log('signup page 리랜더링');
+  const SignupInputs = getValues => {
+    return {
+      email: {
+        attributes: {
+          placeholder: '이메일을 입력해주세요',
+          type: 'email',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '이메일은 필수 입력항목입니다.',
+          },
+          pattern: {
+            value: /[a-z0-9]+@[a-z]+\.[a-z]{2,3}/,
+            message: '올바른 이메일 형식이 아닙니다.',
+          },
+        },
+        options: {
+          inputGuide: '@를 포함한 이메일 주소',
+          label: '이메일',
+        },
+      },
+      password: {
+        attributes: {
+          placeholder: '비밀번호를 입력해주세요.',
+          type: 'text',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '비밀번호는 필수 입력항목입니다.',
+          },
+          pattern: {
+            value:
+              /^(?=.*[a-zA-Z])(?=.*\d|.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$|^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$|^(?=.*\d)(?=.*[!@#$%^&*()_+={}|[\]\\:";'<>?,./])(?=.{8,16}$).*$/,
+            message: '올바른 비밀번호 형식이 아닙니다.',
+          },
+        },
+        options: {
+          inputGuide: '영문 대·소문자/숫자.특수문자 중 2가지 이상 조합, 8~16글자',
+          label: '비밀번호',
+        },
+      },
+      confirmPassword: {
+        attributes: {
+          placeholder: '비밀번호를 입력해주세요',
+          type: 'text',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '비밀번호 확인은 필수 입니다.',
+          },
+          validate: value => {
+            const password = getValues('password');
+            return password === value || '비밀번호가 일치하지 않습니다.';
+          },
+        },
+        options: {
+          label: '비밀번호 확인',
+        },
+      },
+      nickname: {
+        attributes: {
+          placeholder: '닉네임을 입력해주세요',
+          type: 'text',
+        },
+        validate: {
+          required: {
+            value: true,
+            message: '닉네임은 필수 입력항목입니다.',
+          },
+          minLength: {
+            value: 3,
+            message: '닉네임은 3글자 이상 입력해주십시오',
+          },
+          maxLength: {
+            value: 10,
+            message: '닉네임은 10글자를 초과할 수 없습니다.',
+          },
+        },
+        options: {
+          inputGuide: '3글자 이상 10글자 이하',
+          label: '닉네임',
+        },
+      },
+    };
+  };
+
+  const formProps = {
+    onSubmit: onSubmit,
+    headerText: '회원가입',
+    guideText: '회원가입에 필요한 정보를 작성해주세요.',
+    submitButtonText: '가입하기',
+    inputs: SignupInputs,
+    watchTarget: 'password',
+  };
+
+  return (
+    <div className="w-full h-full flex justify-center items-center">
+      <div className="w-full">
+        <Form {...formProps}>
+          <Button className="w-full">
+            <Link to="/">이전으로 돌아가기</Link>
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
 };
 
 export default SignupPage;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,0 +1,3 @@
+export { default as HomePage } from './Homepage';
+export { default as SigninPage } from './SigninPage';
+export { default as SignupPage } from './SignupPage';

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -17,23 +17,23 @@ const router = createBrowserRouter([
         path: '',
         element: <HomePage />,
       },
+    ],
+  },
+  {
+    path: '/auth',
+    element: <AuthLayout />,
+    children: [
       {
-        path: 'auth',
-        element: <AuthLayout />,
-        children: [
-          {
-            path: '',
-            element: <SigninPage />,
-          },
-          {
-            path: 'signup',
-            element: <SignupPage />,
-          },
-          {
-            path: '*',
-            element: <Navigate to="/auth" replace />,
-          },
-        ],
+        path: '',
+        element: <SigninPage />,
+      },
+      {
+        path: 'signup',
+        element: <SignupPage />,
+      },
+      {
+        path: '*',
+        element: <Navigate to="/auth" replace />,
       },
     ],
   },

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -1,0 +1,42 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+
+import DefaultLayout from '../layouts/DefaultLayout';
+import { HomePage } from '../pages';
+import AuthLayout from '../layouts/AuthLayout';
+import SigninPage from '../pages/SigninPage';
+import SignupPage from '../pages/SignupPage';
+
+// TODO : errorElement 추가하기
+// TODO : Path 상수화하기
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <DefaultLayout />,
+    children: [
+      {
+        path: '',
+        element: <HomePage />,
+      },
+      {
+        path: 'auth',
+        element: <AuthLayout />,
+        children: [
+          {
+            path: '',
+            element: <SigninPage />,
+          },
+          {
+            path: 'signup',
+            element: <SignupPage />,
+          },
+          {
+            path: '*',
+            element: <Navigate to="/auth" replace />,
+          },
+        ],
+      },
+    ],
+  },
+]);
+
+export default router;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },
   plugins: [],
-}
-
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,12 @@
 /** @type {import('tailwindcss').Config} */
+
+const pxToRem = require('tailwindcss-preset-px-to-rem');
+
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },
   plugins: [],
+  presets: [pxToRem],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3434,6 +3434,11 @@ synckit@^0.9.1:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
+tailwindcss-preset-px-to-rem@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss-preset-px-to-rem/-/tailwindcss-preset-px-to-rem-1.2.1.tgz#88f99099a61a02518d8cf1318b6b873a743b3b59"
+  integrity sha512-m3GHwciFiXZviaN7WvOiiMjRBT7razJxgPTY6h2KcOvzvkOTysOV6gN3HkejfXUyL4DKx6YjiPcLCqv6yMeXHw==
+
 tailwindcss@^3.4.17:
   version "3.4.17"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.17.tgz#ae8406c0f96696a631c790768ff319d46d5e5a63"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,6 +1026,18 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+autoprefixer@^10.4.20:
+  version "10.4.20"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
+  integrity sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==
+  dependencies:
+    browserslist "^4.23.3"
+    caniuse-lite "^1.0.30001646"
+    fraction.js "^4.3.7"
+    normalize-range "^0.1.2"
+    picocolors "^1.0.1"
+    postcss-value-parser "^4.2.0"
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -1065,7 +1077,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.23.3, browserslist@^4.24.0:
   version "4.24.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -1111,7 +1123,7 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-caniuse-lite@^1.0.30001688:
+caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
   version "1.0.30001692"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz#4585729d95e6b95be5b439da6ab55250cd125bf9"
   integrity sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==
@@ -1744,6 +1756,11 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
+fraction.js@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
+  integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -2343,6 +2360,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
+
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2474,7 +2496,7 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -2538,12 +2560,12 @@ postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.0.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.47, postcss@^8.4.49:
+postcss@^8.4.47, postcss@^8.4.49, postcss@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.1.tgz#e2272a1f8a807fafa413218245630b5db10a3214"
   integrity sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- (#2) feature/auth

### 📍변경 사항
로그인, 회원가입을 위한 SigninPage, SignupPage를 만들고 라우터를 추가했습니다.

#### Auth 레이아웃 추가
- 로그인, 회원가입 페이지를 위한 AuthLayout이 추가되었습니다. ( 레이아웃 스타일링 완성)
- Header /Content/Footer 구성

#### 라우터 추가
- /auth 하위의 정의되지 않은 url은 /auth로 접근하여 기본 로그인 페이지를 보여줍니다.
```javascript
{
    path: '/auth',
    element: <AuthLayout />,
    children: [
      {
        path: '',
        element: <SigninPage />,
      },
      {
        path: 'signup',
        element: <SignupPage />,
      },
      {
        path: '*',
        element: <Navigate to="/auth" replace />,
      },
    ],
  },
```

#### tailwind에서 pxr 단위를 사용
이를 위해 `[[tailwindcss-preset-px-to-rem]]`패키지가 추가되었습니다.
- 개발시에는 px로 설정하되 실제 브라우저에서는 rem 단위로 적용됩니다.
- 기존의 tailwind와 다른 사용방식을 가지고 있으므로 유의해야합니다.
- 기존 : `w-[32px]`일경우 px 단위로 적용됩니다. 'w-32'일경우 `8rem(128px)`으로 적용됩니다.
- pxr : 32px을 적용하고 싶을 경우 `w-32`로 적어주시면 됩니다. 

### ✅need to review

####  form, input 재사용성을 위한 도메인로직, 뷰 분리
-  Form 컴포넌트만 react-hook-form 라이브러리 관련 의존성을 가집니다.
-  Form 내부의 모든 input 요소와 validation은 상위의 SigninPage, SignupPage에서 관리됩니다.
-  Button, Input은 view에만 집중합니다.

#### Page export 방식 변경
```plain
src/pages/Home

pages
└index.js // 여기서 모든 페이지를 내보냅니다. -> 라우터에서 임포트 구문이 간결해집니다.
└Home
	└index.jsx // 여기에 기존 페이지를 작성하면 됩니다.
	└HomePage.loader.js /
	└components // 해당 페이지 내부에서반 사용되는 컴포넌트가 있다면 여기에 정의

``` 
