### PR TITLE
[FEAT] 로그인/회원 가입 api 연결, 유저정보를 redux와 쿠키에서 관리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# env
+.env

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.64.1",
     "antd": "^5.23.1",
     "autoprefixer": "^10.4.20",
+    "axios": "^1.7.9",
     "postcss": "^8.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-redux": "^9.2.0",
     "react-router": "^7.1.3",
     "react-router-dom": "^7.1.3",
+    "redux-persist": "^6.0.0",
     "tailwindcss-preset-px-to-rem": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.7.9",
     "postcss": "^8.5.1",
     "react": "^18.3.1",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,11 +5,14 @@ import { Provider } from 'react-redux';
 import store from './redux/store';
 import { PersistGate } from 'redux-persist/integration/react';
 import { persistStore } from 'redux-persist';
+import { CookiesProvider } from 'react-cookie';
 function App() {
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistStore(store)}>
-        <RouterProvider router={router} />
+        <CookiesProvider>
+          <RouterProvider router={router} />
+        </CookiesProvider>
       </PersistGate>
     </Provider>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,14 @@ import { RouterProvider } from 'react-router-dom';
 import router from './routes/router';
 import { Provider } from 'react-redux';
 import store from './redux/store';
-
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
 function App() {
   return (
     <Provider store={store}>
-      <RouterProvider router={router} />
+      <PersistGate loading={null} persistor={persistStore(store)}>
+        <RouterProvider router={router} />
+      </PersistGate>
     </Provider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,15 @@
 import './App.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './routes/router';
+import { Provider } from 'react-redux';
+import store from './redux/store';
 
 function App() {
-  console.log('hello world');
-  return <RouterProvider router={router} />;
+  return (
+    <Provider store={store}>
+      <RouterProvider router={router} />
+    </Provider>
+  );
 }
 
 export default App;

--- a/src/apis/endpoints.js
+++ b/src/apis/endpoints.js
@@ -1,0 +1,3 @@
+export const serverURL = import.meta.env.VITE_API_BASE_URL;
+
+// TODO : api endpoint 객체로 관리

--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -1,0 +1,44 @@
+import { serverURL } from './endpoints';
+import axios from 'axios';
+
+// TODO : Error message template 생성
+// TODO : req 확인 후 console.log 제거
+export const postSignupApi = async data => {
+  const { email, password, nickname } = data;
+
+  const url = `${serverURL}/signup`;
+  try {
+    const response = await axios.post(url, {
+      email,
+      password,
+      fullName: nickname,
+    });
+    console.log('sign up res', response);
+    if (!response.ok) {
+      console.log('sign up api 문제');
+    }
+    return response.data;
+  } catch (error) {
+    console.log('error', error);
+  }
+};
+
+export const postSigninApi = async data => {
+  const { email, password } = data;
+  const url = `${serverURL}/login`;
+
+  try {
+    const response = await axios.post(url, {
+      email,
+      password,
+    });
+
+    console.log('login res', response);
+    if (!response.ok) {
+      console.log('login 문제');
+    }
+    return response.data;
+  } catch (error) {
+    console.log('error', error);
+  }
+};

--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -34,9 +34,7 @@ export const postSigninApi = async data => {
     });
 
     console.log('login res', response);
-    if (!response.ok) {
-      console.log('login 문제');
-    }
+
     return response.data;
   } catch (error) {
     console.log('error', error);

--- a/src/pages/Homepage/index.jsx
+++ b/src/pages/Homepage/index.jsx
@@ -7,7 +7,7 @@ const HomePage = () => {
   return (
     <div>
       HomePage
-      <p>user가 있습니까? {user.userEmail !== '' ? 'yes' : 'no'}</p>
+      <p>user가 있습니까? {user !== '' ? 'yes' : 'no'}</p>
     </div>
   );
 };

--- a/src/pages/Homepage/index.jsx
+++ b/src/pages/Homepage/index.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 const HomePage = () => {
-  return <div>HomePage</div>;
+  const user = useSelector(state => state.user);
+  console.log('user-redux', user);
+  return (
+    <div>
+      HomePage
+      <p>user가 있습니까? {user.userEmail !== '' ? 'yes' : 'no'}</p>
+    </div>
+  );
 };
 
 export default HomePage;

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button } from 'antd';
 import { postSigninApi } from '../../apis/user';
 import { setUser } from '../../redux/slices/user.slice';
+import { setCookie } from '../../utils/cookie';
 // 로그인
 const SigninPage = () => {
   const navigate = useNavigate();
@@ -26,6 +27,8 @@ const SigninPage = () => {
         userId: result.user._id,
         userFullName: result.user.fullName,
       };
+      // 쿠키에 jwt 저장
+      setCookie('jwt', jwt, { path: '/' });
 
       // 사용자 정보를 redux에 저장
       dispatch(

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -1,10 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import Form from '../../components/common/Form';
 import { Link } from 'react-router-dom';
 import { Button } from 'antd';
 import { postSigninApi } from '../../apis/user';
-
+import { setUser } from '../../redux/slices/user.slice';
 // 로그인
 const SigninPage = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
   const onSubmit = async data => {
     const { email, password } = data;
     const loginReqData = { email, password };
@@ -21,9 +26,17 @@ const SigninPage = () => {
         userId: result.user._id,
         userFullName: result.user.fullName,
       };
-    }
 
-    // 사용자 정보를 redux에 저장
+      // 사용자 정보를 redux에 저장
+      dispatch(
+        setUser({
+          ...userData,
+        }),
+      );
+
+      // 메인화면으로 이동
+      navigate('/');
+    }
   };
 
   const SigninInputs = getValues => {

--- a/src/pages/SigninPage/index.jsx
+++ b/src/pages/SigninPage/index.jsx
@@ -1,11 +1,29 @@
 import Form from '../../components/common/Form';
 import { Link } from 'react-router-dom';
 import { Button } from 'antd';
+import { postSigninApi } from '../../apis/user';
 
 // 로그인
 const SigninPage = () => {
-  const onSubmit = data => {
-    console.log('do something');
+  const onSubmit = async data => {
+    const { email, password } = data;
+    const loginReqData = { email, password };
+
+    // 로그인 요청
+    const result = await postSigninApi(loginReqData);
+
+    // userData를 전역에 저장
+    if (result) {
+      // result의 토큰과 유저정보 받아오기
+      const jwt = result.token;
+      const userData = {
+        userEmail: result.user.email,
+        userId: result.user._id,
+        userFullName: result.user.fullName,
+      };
+    }
+
+    // 사용자 정보를 redux에 저장
   };
 
   const SigninInputs = getValues => {

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button } from 'antd';
 import Form from '../../components/common/Form';
 import { postSignupApi } from '../../apis/user';
+import { setUser } from '../../redux/slices/user.slice';
 
 const SignupPage = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+
   const onSubmit = async data => {
     const { email, nickname, password } = data;
     const signUpReqData = {
@@ -28,6 +32,14 @@ const SignupPage = () => {
       };
 
       // 사용자 정보를 redux에 저장
+      dispatch(
+        setUser({
+          ...userData,
+        }),
+      );
+
+      // 메인 화면으로 이동
+      navigate('/');
     }
   };
 

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -6,6 +6,7 @@ import { Button } from 'antd';
 import Form from '../../components/common/Form';
 import { postSignupApi } from '../../apis/user';
 import { setUser } from '../../redux/slices/user.slice';
+import { setCookie } from '../../utils/cookie';
 
 const SignupPage = () => {
   const navigate = useNavigate();
@@ -30,6 +31,9 @@ const SignupPage = () => {
         userId: result.user._id,
         userFullName: result.user.fullName,
       };
+
+      //쿠키에 jwt 저장
+      setCookie('jwt', jwt, { path: '/' });
 
       // 사용자 정보를 redux에 저장
       dispatch(

--- a/src/pages/SignupPage/index.jsx
+++ b/src/pages/SignupPage/index.jsx
@@ -1,14 +1,36 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { Button } from 'antd';
 import Form from '../../components/common/Form';
+import { postSignupApi } from '../../apis/user';
 
 const SignupPage = () => {
-  const onSubmit = data => {
-    console.log('do something');
+  const navigate = useNavigate();
+  const onSubmit = async data => {
+    const { email, nickname, password } = data;
+    const signUpReqData = {
+      email,
+      nickname,
+      password,
+    };
+    // 회원가입 요청
+    const result = await postSignupApi(signUpReqData);
+
+    // userData를 전역에 저장
+    if (result) {
+      // result 의 토큰과 유저정보 받아오기
+      const jwt = result.token;
+      const userData = {
+        userEmail: result.user.email,
+        userId: result.user._id,
+        userFullName: result.user.fullName,
+      };
+
+      // 사용자 정보를 redux에 저장
+    }
   };
 
-  console.log('signup page 리랜더링');
   const SignupInputs = getValues => {
     return {
       email: {

--- a/src/redux/slices/user.slice.js
+++ b/src/redux/slices/user.slice.js
@@ -1,0 +1,24 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  userEmail: '',
+  userId: '',
+  userFullName: '',
+};
+
+const userSlice = createSlice({
+  initialState,
+  name: 'user',
+  reducers: {
+    setUser: (state, action) => {
+      const userData = action.payload;
+      state.userEmail = userData.userEmail;
+      state.userId = userData.userId;
+      state.userFullName = userData.userFullName;
+    },
+  },
+});
+
+export const userReducer = userSlice.reducer;
+
+export const { setUser } = userSlice.actions;

--- a/src/redux/slices/user.slice.js
+++ b/src/redux/slices/user.slice.js
@@ -1,19 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  userEmail: '',
   userId: '',
+  userEmail: '',
   userFullName: '',
 };
 
-const userSlice = createSlice({
+export const userSlice = createSlice({
   initialState,
   name: 'user',
   reducers: {
     setUser: (state, action) => {
       const userData = action.payload;
-      state.userEmail = userData.userEmail;
       state.userId = userData.userId;
+      state.userEmail = userData.userEmail;
       state.userFullName = userData.userFullName;
     },
   },

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,17 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { userReducer } from './slices/user.slice';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'; // ? 창이 닫힐 때 유저정보가 삭제되길 원한다면 session storage로 변경
 
 const store = configureStore({
-  reducer: {},
+  reducer: {
+    user: userReducer,
+  },
 });
 
+const persistConfig = {
+  key: 'root',
+  storage, // 기본적으로는 local storage
+  whitelist: ['user'], // 'user'리듀서만 persist하게 설정
+};
 export default store;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,17 +1,27 @@
-import { configureStore } from '@reduxjs/toolkit';
-import { userReducer } from './slices/user.slice';
-import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage'; // ? 창이 닫힐 때 유저정보가 삭제되길 원한다면 session storage로 변경
-
-const store = configureStore({
-  reducer: {
-    user: userReducer,
-  },
-});
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { userSlice } from './slices/user.slice';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage/session'; // 세션 스토리지에 저장
 
 const persistConfig = {
   key: 'root',
-  storage, // 기본적으로는 local storage
-  whitelist: ['user'], // 'user'리듀서만 persist하게 설정
+  storage,
+  whitelist: ['user'], // 'user'리듀서만 persist하게 설정,
+  timeout: 1000,
 };
+
+const reducers = combineReducers({
+  user: userSlice.reducer,
+});
+
+const persistedReducer = persistReducer(persistConfig, reducers);
+
+const store = configureStore({
+  reducer: persistedReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+
 export default store;

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -1,0 +1,15 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const setCookie = (name, value, options) => {
+  return cookies.set(name, value, { ...options });
+};
+
+export const getCookie = name => {
+  return cookies.get(name);
+};
+
+export const removeCookie = name => {
+  return cookies.remove(name, { path: '/' });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,6 +791,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/hoist-non-react-statics@^3.3.5":
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz#6bba74383cdab98e8db4e20ce5b4a6b98caed010"
+  integrity sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -805,6 +813,13 @@
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
+
+"@types/react@*":
+  version "19.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.7.tgz#c451968b999d1cb2d9207dc5ff56496164cf511d"
+  integrity sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==
+  dependencies:
+    csstype "^3.0.2"
 
 "@types/react@^18.3.18":
   version "18.3.18"
@@ -1213,6 +1228,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookie@^1.0.1:
   version "1.0.2"
@@ -1962,6 +1982,13 @@ hasown@^2.0.0, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -3017,6 +3044,15 @@ rc-virtual-list@^3.14.2, rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
 
+react-cookie@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-7.2.2.tgz#a7559e552ea9cca39a4b3686723a5acf504b8f84"
+  integrity sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.5"
+    hoist-non-react-statics "^3.3.2"
+    universal-cookie "^7.0.0"
+
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -3030,7 +3066,7 @@ react-hook-form@^7.54.2:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
   integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3636,6 +3672,14 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
+
+universal-cookie@^7.0.0:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-7.2.2.tgz#93ae9ec55baab89b24300473543170bb8112773c"
+  integrity sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.7.2"
 
 update-browserslist-db@^1.1.1:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,6 +1026,11 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@^10.4.20:
   version "10.4.20"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
@@ -1044,6 +1049,15 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1167,6 +1181,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^4.0.0:
   version "4.1.1"
@@ -1292,6 +1313,11 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1741,6 +1767,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1755,6 +1786,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.3.7:
   version "4.3.7"
@@ -2307,6 +2347,18 @@ micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2599,6 +2651,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- ( #8 ) feature/auth

### 변경 사항
- 로그인/ 회원가입 기능 구현이 완료되었습니다.

#### 의존성 추가
- `react-cookie` : jwt를 쿠키에 저장합니다. dev-course제공 api에서는 쿠키에서 jwt를 꺼내 헤더에 담아보내야합니다.
- `redux-persist` : 로그인 후 새로고침시 전역상태가 소실되는 이슈가 있었습니다. 이제 유저 정보 (email, fullname, id)를 세션 스토리지에 저장합니다. 새로 고침하여도 유저정보는 남아있고, 창이 닫힐때 유저정보가 소실되게 됩니다.


