### PR TITLE
feat : 내 일정 페이지에서 일정 정렬 및 메인페이지 컴포넌트 구현

### DIFF
--- a/src/constants/mainExamplePlaces.js
+++ b/src/constants/mainExamplePlaces.js
@@ -1,0 +1,50 @@
+export const tourPlaces = [
+  {
+    title: "우도(해양도립공원)",
+    city: "우도",
+    street: "제주시 우도면 삼양고수물길 1", // 도로명 주소 적용
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/202408/21/92bf5bba-77fc-4829-8555-5076b2e7bb52.jpg",
+    description: "소가 누워있는 형상을 하고 있는 제주의 가장 큰 부속섬",
+    category: "관광지"
+  },
+  {
+    title: "카멜리아힐",
+    city: "서귀포시",
+    street: "서귀포시 안덕면 병악로 166", // 도로명 주소 적용
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/202410/15/5293c237-e9d4-4b12-9a8d-a32724958b9b.jpg",
+    description: "커플들과 아이를 동반한 가족 단위 관광객에게 인기가 높은 동양에서 가장 큰 동백 수목원",
+    category: "관광지"
+  },
+  {
+    title: "새별오름",
+    city: "제주시",
+    street: "제주시 애월읍 봉성리 산 59-8", // 도로명 주소 없음 (지번 주소 유지)
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/202410/21/2a2a3ba3-e7c4-49f5-9409-da274ca547cb.jpg",
+    description: "제주 서부 애월에 위치해 있으며 억새가 아름다운 오름",
+    category: "관광지"
+  },
+  {
+    title: "금능해수욕장",
+    city: "제주시",
+    street: "제주시 한림읍 금능길 119-10", // 도로명 주소 적용
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/202110/25/120296bb-0959-4579-ad37-c559e95b434c.JPG",
+    description: "제주시 한림읍에 위치한 금능해수욕장은 협재해수욕장과 바로 이어져 있어 여유로운 분위기가 매력이다.",
+    category: "관광지"
+  },
+  {
+    title: "용두암",
+    city: "제주시",
+    street: "제주시 용두암길 15", // 도로명 주소 적용
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/201804/30/39fa654e-5805-4d29-9dfc-e8950f29292a.jpg",
+    description: "용이 승천하려다 뜻을 이루지 못했다는 전설을 담고 있는 곳",
+    category: "관광지"
+  },
+  {
+    title: "한림공원",
+    city: "제주시",
+    street: "제주시 한림읍 한림로 300", // 도로명 주소 적용
+    img: "https://api.cdn.visitjeju.net/photomng/thumbnailpath/202205/30/58ce2ef7-c996-462e-aa99-eb613c01e95a.jpg",
+    description: "10만 평 대지 위에 펼쳐지는 환상적인 10가지 테마파크.",
+    category: "관광지"
+  }
+];

--- a/src/pages/Homepage/components/SearchPreview/MainCard.jsx
+++ b/src/pages/Homepage/components/SearchPreview/MainCard.jsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+const MainCard = ({ title, city, street, img }) => {
+  return (
+    <div className="border-solid border border-[#E9E9E9] rounded-8  shadow-lg w-313 overflow-hidden [&:nth-child(3n)]:mr-0">
+      <img className="h-209 w-full" src={img} alt="상세 사진" />
+      <div className="p-20">
+        <div className="flex justify-between mb-13">
+          <div className="text-18 font-semibold line-clamp-1">{title}</div>
+          <button>
+            <img src="/icons/scrap-icon.svg" className="w-21 h-19" alt="스크랩 아이콘" />
+          </button>
+        </div>
+        <div className="text-14 text-gray-5">{`${city} > ${street}`}</div>
+      </div>
+    </div>
+  );
+};
+
+export default MainCard;
+
+MainCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  city: PropTypes.string.isRequired,
+  street: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  img: PropTypes.string.isRequired,
+  category: PropTypes.string.isRequired,
+};

--- a/src/pages/Homepage/components/SearchPreview/index.jsx
+++ b/src/pages/Homepage/components/SearchPreview/index.jsx
@@ -1,0 +1,49 @@
+import { tourPlaces } from '../../../../constants/mainExamplePlaces.js';
+import MainCard from './MainCard.jsx';
+import catetoryCode from '../../../../constants/category.js';
+
+const SearchPreview = () => {
+  return (
+    <div className="h-903 w-full bg-gray-2 flex flex-col justify-center items-center gap-20">
+      <div className="flex w-945 justify-between">
+        <div className="flex text-40 font-extrabold">
+          <div>⛰️&nbsp;</div>
+          <div className="text-sub-accent-1">LOOKING&nbsp;</div>
+          <div className="text-gray-12">for&nbsp;</div>
+          <div className="text-primary-0">Jeju</div>
+        </div>
+        <a href="/search">
+          <button className="w-521 h-52 bg-white rounded-40 shadow-[0px_2px_10px_0px_rgba(0,0,0,0.25)] text-gray-6">
+            여기를 클릭해 제주도 장소를 검색해보세요!
+          </button>
+        </a>
+      </div>
+      <div className="flex w-582 justify-between">
+        {catetoryCode.map((item, index) => (
+          <button key={index} className="w-75 h-37 bg-gray-4 rounded-30 text-gray-8 text-14">
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex w-940 justify-between mx-13">
+        <div className="text-gray-8 font-semibold">📍 제주도 추천 명소</div>
+        <button className="text-sub-accent-1 font-bold">더보기</button>
+      </div>
+      <div className="grid grid-cols-3 grid-rows-2 place-items-center gap-15">
+        {tourPlaces.map((item, index) => (
+          <MainCard
+            key={index}
+            title={item.title}
+            city={item.city}
+            street={item.street}
+            img={item.img}
+            description={item.description}
+            category={item.category}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SearchPreview;

--- a/src/pages/Homepage/components/index.js
+++ b/src/pages/Homepage/components/index.js
@@ -1,3 +1,4 @@
 export { default as Hero } from './Hero';
 export { default as CarouselWrapper } from './Carousel/CarouselWrapper';
 export { default as PlanPreview } from './PlanPreview';
+export { default as SearchPreview } from './SearchPreview';

--- a/src/pages/Homepage/index.jsx
+++ b/src/pages/Homepage/index.jsx
@@ -1,4 +1,4 @@
-import { Hero, CarouselWrapper, PlanPreview } from './components';
+import { Hero, CarouselWrapper, PlanPreview, SearchPreview } from './components';
 
 const HomePage = () => {
   return (
@@ -6,6 +6,7 @@ const HomePage = () => {
       <Hero />
       <CarouselWrapper />
       <PlanPreview />
+      <SearchPreview />
       <div>다음 컴포넌트</div>
     </div>
   );

--- a/src/pages/MyTripPage/index.jsx
+++ b/src/pages/MyTripPage/index.jsx
@@ -39,7 +39,7 @@ const MyTripPage = () => {
   const sortDatesData = (data) => {
     const sortedDatesData = [];
     Object.keys(data).forEach(date => {
-      sortedDatesData[date] = datesData[date].sort((a, b) => a.time.localeCompare(b.time));
+      sortedDatesData[date] = data[date].sort((a, b) => a.time.localeCompare(b.time));
     })
     return sortedDatesData;
   }
@@ -58,8 +58,7 @@ const MyTripPage = () => {
           tempDatesData[planInfo.date].push(planInfo);
         }
       }
-      // setDatesData(sortDatesData(tempDatesData));
-      setDatesData(tempDatesData);
+      setDatesData(sortDatesData(tempDatesData));
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main -> main

### 변경 사항
- 내 일정 페이지에서 일정들이 시간별로 정렬되도록 구현했습니다
- 메인페이지에서 검색으로 넘어가는 쪽 컴포넌트 구현했습니다
<img width="1154" alt="스크린샷 2025-02-01 오전 2 09 02" src="https://github.com/user-attachments/assets/383aa8fa-0b9d-4342-a88a-5335ced0f50a" />

