### PR TITLE
feat : 메인페이지 커뮤니티 캐러셀 구현 (#86)

### DIFF
--- a/src/hooks/react-query/useFetchCommunityPost.js
+++ b/src/hooks/react-query/useFetchCommunityPost.js
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchChannels } from '@/apis/channelApi';
+import { getPostByChannelApi } from '@/apis/postApi';
+
+const useFetchCommunityPost = () => {
+  //1. 모든 채널 조회
+  const { data: channels } = useQuery({
+    queryKey: ['channel', 'list'],
+    queryFn: () => fetchChannels(),
+  });
+
+  //2. 관광지 채널의 posts만 조회
+  const {
+    data: postsData,
+    isLoading,
+    isSuccess,
+  } = useQuery({
+    queryKey: ['post', 'list', { category: 'attractions' }],
+    queryFn: () => {
+      if (!channels) return [];
+      const attractionId = channels[0]['_id'];
+      return Promise.all([getPostByChannelApi(attractionId)]);
+    },
+    enabled: !!channels,
+  });
+
+  console.log(isSuccess);
+  if (isSuccess) {
+    console.log(postsData);
+    let posts = postsData[0];
+    return { posts, isLoading, isSuccess };
+  } else {
+    return { posts: postsData, isLoading, isSuccess };
+  }
+};
+
+export default useFetchCommunityPost;

--- a/src/pages/Homepage/components/Carousel/Carousel.jsx
+++ b/src/pages/Homepage/components/Carousel/Carousel.jsx
@@ -50,7 +50,13 @@ const Carousel = ({ options, items }) => {
 
         const tweenValue = 1 - Math.abs(diffToTarget * tweenFactor.current);
         const opacity = numberWithinRange(tweenValue, 0, 1).toString();
-        emblaApi.slideNodes()[slideIndex].style.opacity = opacity;
+        const brightness = numberWithinRange(tweenValue, 0.5, 1).toString();
+        const height = numberWithinRange(tweenValue, 0.9, 1).toString();
+        emblaApi.slideNodes()[slideIndex].style.filter = `brightness(${brightness})`;
+        emblaApi.slideNodes()[slideIndex].querySelector('a').querySelector('img').style.height =
+          `${19 * height}em`;
+        emblaApi.slideNodes()[slideIndex].querySelector('div').style.opacity =
+          `${opacity < 0.2 ? 0 : opacity}`;
       });
     });
   }, []);
@@ -68,7 +74,7 @@ const Carousel = ({ options, items }) => {
   }, [emblaApi, tweenOpacity]);
 
   return (
-    <div className="my-30 relative">
+    <div className="my-30 h-400 relative">
       <div className="embla">
         <div className="embla__viewport" ref={emblaRef}>
           <div className="embla__container">
@@ -92,12 +98,16 @@ const Carousel = ({ options, items }) => {
         </div>
       </div>
 
-      <div className="embla__controls">
+      {/* <div className=" h-63 flex place-content-between absolute bottom-0 w-full">
+        <div className="w-200 h-62 bg-white"></div>
+        <div className="w-200 h-62 bg-white"></div>
+      </div> */}
+      {/* <div className="embla__controls">
         <div className="embla__buttons">
           <PrevButton onClick={onPrevButtonClick} disabled={prevBtnDisabled} />
           <NextButton onClick={onNextButtonClick} disabled={nextBtnDisabled} />
         </div>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/pages/Homepage/components/Carousel/Carousel.jsx
+++ b/src/pages/Homepage/components/Carousel/Carousel.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { NextButton, PrevButton, usePrevNextButtons } from './EmblaCarouselArrowButtons';
 import { Link } from 'react-router';
 import useEmblaCarousel from 'embla-carousel-react';
@@ -11,8 +11,7 @@ const numberWithinRange = (number, min, max) => Math.min(Math.max(number, min), 
 const Carousel = ({ options, items }) => {
   const [emblaRef, emblaApi] = useEmblaCarousel(options);
   const tweenFactor = useRef(0);
-  const { prevBtnDisabled, nextBtnDisabled, onPrevButtonClick, onNextButtonClick } =
-    usePrevNextButtons(emblaApi);
+  const [scrollProgress, setScrollProgress] = useState(0);
 
   const setTweenFactor = useCallback(emblaApi => {
     tweenFactor.current = TWEEN_FACTOR_BASE * emblaApi.scrollSnapList().length;
@@ -20,6 +19,7 @@ const Carousel = ({ options, items }) => {
 
   const tweenOpacity = useCallback((emblaApi, eventName) => {
     const engine = emblaApi.internalEngine();
+
     const scrollProgress = emblaApi.scrollProgress();
     const slidesInView = emblaApi.slidesInView();
     const isScrollEvent = eventName === 'scroll';
@@ -60,22 +60,29 @@ const Carousel = ({ options, items }) => {
       });
     });
   }, []);
-
+  const onScroll = useCallback(emblaApi => {
+    const progress = Math.max(0, Math.min(1, emblaApi.scrollProgress()));
+    setScrollProgress(progress * 100);
+  }, []);
   useEffect(() => {
     if (!emblaApi) return;
-
+    onScroll(emblaApi);
     setTweenFactor(emblaApi);
     tweenOpacity(emblaApi);
     emblaApi
       .on('reInit', setTweenFactor)
       .on('reInit', tweenOpacity)
       .on('scroll', tweenOpacity)
-      .on('slideFocus', tweenOpacity);
-  }, [emblaApi, tweenOpacity]);
+      .on('slideFocus', tweenOpacity)
+      .on('reInit', onScroll)
+      .on('scroll', onScroll)
+      .on('slideFocus', onScroll);
+  }, [emblaApi, tweenOpacity, onScroll]);
 
+  console.log('scrollProgress', scrollProgress);
   return (
-    <div className="my-30 h-400 relative">
-      <div className="embla">
+    <div className="my-30 relative">
+      <div className="embla h-400">
         <div className="embla__viewport" ref={emblaRef}>
           <div className="embla__container">
             {items.map((item, index) => (
@@ -98,16 +105,14 @@ const Carousel = ({ options, items }) => {
         </div>
       </div>
 
-      {/* <div className=" h-63 flex place-content-between absolute bottom-0 w-full">
-        <div className="w-200 h-62 bg-white"></div>
-        <div className="w-200 h-62 bg-white"></div>
-      </div> */}
-      {/* <div className="embla__controls">
-        <div className="embla__buttons">
-          <PrevButton onClick={onPrevButtonClick} disabled={prevBtnDisabled} />
-          <NextButton onClick={onNextButtonClick} disabled={nextBtnDisabled} />
+      <div className="w-full  flex justify-center items-center">
+        <div className="embla__progress bg-gray-5">
+          <div
+            className="embla__progress__bar bg-primary-1"
+            style={{ transform: `translate3d(${scrollProgress}%,0px,0px)` }}
+          />
         </div>
-      </div> */}
+      </div>
     </div>
   );
 };

--- a/src/pages/Homepage/components/Carousel/style.css
+++ b/src/pages/Homepage/components/Carousel/style.css
@@ -10,6 +10,7 @@
 }
 .embla__container {
   display: flex;
+  align-items: center;
   touch-action: pan-y pinch-zoom;
   margin-left: calc(var(--slide-spacing) * -1);
 }

--- a/src/pages/Homepage/components/Carousel/style.css
+++ b/src/pages/Homepage/components/Carousel/style.css
@@ -34,43 +34,19 @@
     0px 2px 4px 0 rgba(0, 0, 0, 0.1);
 }
 
-.embla__controls {
-  position: absolute;
-  top: 150px;
-  z-index: 30;
-  width: 100%;
-}
-.embla__buttons {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-.embla__button {
-  -webkit-tap-highlight-color: rgba(var(--text-high-contrast-rgb-value), 0.5);
-  -webkit-appearance: none;
-  appearance: none;
-  background-color: transparent;
-  touch-action: manipulation;
-  display: inline-flex;
-  text-decoration: none;
-  cursor: pointer;
-  border: 0;
-  padding: 0;
-  margin: 0;
+.embla__progress {
+  border-radius: 1.8rem;
   box-shadow: inset 0 0 0 0.2rem var(--detail-medium-contrast);
-  width: 3.6rem;
-  height: 3.6rem;
-  z-index: 1;
-  border-radius: 50%;
-  color: var(--text-body);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: relative;
+  height: 0.6rem;
+  width: 36rem;
+  max-width: 90%;
+  overflow: hidden;
 }
-.embla__button:disabled {
-  color: var(--detail-high-contrast);
-}
-.embla__button__svg {
-  width: 35%;
-  height: 35%;
+.embla__progress__bar {
+  position: absolute;
+  width: 100%;
+  top: 0;
+  bottom: 0;
+  left: -100%;
 }

--- a/src/pages/Homepage/components/Community/Carousel.jsx
+++ b/src/pages/Homepage/components/Community/Carousel.jsx
@@ -1,0 +1,65 @@
+import { useState, useCallback, useEffect } from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
+import './preview-style.css';
+
+const Carousel = ({ slides, options }) => {
+  const [emblaRef, emblaApi] = useEmblaCarousel(options);
+  const [prevBtnDisabled, setPrevBtnDisabled] = useState(true);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
+
+  const onPrevButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollPrev();
+  }, [emblaApi]);
+
+  const onNextButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollNext();
+  }, [emblaApi]);
+
+  const onSelect = useCallback(emblaApi => {
+    setPrevBtnDisabled(!emblaApi.canScrollPrev());
+    setNextBtnDisabled(!emblaApi.canScrollNext());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onSelect(emblaApi);
+    emblaApi.on('reInit', onSelect).on('select', onSelect);
+  }, [emblaApi, onSelect]);
+  return (
+    <div className="relative">
+      <div className="community-embla">
+        <div className="community-embla__viewport" ref={emblaRef}>
+          <div className="community-embla__container">
+            {slides.map((slide, index) => (
+              <div className="community-embla__slide" key={index}>
+                <div>{slide}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="community-embla__controls">
+          <div className="community-embla__buttons">
+            <button
+              onClick={onPrevButtonClick}
+              disabled={prevBtnDisabled}
+              className="absolute top-133 -left-35  w-30 h-30 flex justify-center items-center rounded-full shadow-2md"
+            >
+              <img src={'/public/icons/left-array.svg'} />
+            </button>
+            <button
+              onClick={onNextButtonClick}
+              disabled={nextBtnDisabled}
+              className="absolute top-133 -right-35  w-30 h-30 flex justify-center items-center rounded-full shadow-2md"
+            >
+              <img src={'/public/icons/right-array2.svg'} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default Carousel;

--- a/src/pages/Homepage/components/Community/CommunityPreviewCard.jsx
+++ b/src/pages/Homepage/components/Community/CommunityPreviewCard.jsx
@@ -1,0 +1,19 @@
+import PNG_IMAGES from '@public/images/image';
+
+const CommunityPreviewCard = ({ post }) => {
+  return (
+    <div className="w-475 h-139 flex gap-17 justify-center items-center border border-solid border-gray-5 bg-gray-2 rounded-17">
+      <div>
+        <img
+          src={post.image ? `${post.image}` : `${PNG_IMAGES.defaultCard}`}
+          className="w-97 h-97 rounded-9"
+        />
+      </div>
+      <div className="flex flex-col gap-10 w-325">
+        <div className="font-semibold text-18 text-gray-8">{post?.author?.fullName}</div>
+        <div className="font-regular text-15 text-gray-7">{post.title.slice(0, 80)}</div>
+      </div>
+    </div>
+  );
+};
+export default CommunityPreviewCard;

--- a/src/pages/Homepage/components/Community/index.jsx
+++ b/src/pages/Homepage/components/Community/index.jsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router';
+import useFetchCommunityPost from '@/hooks/react-query/useFetchCommunityPost';
+import CommunityPreviewCard from './CommunityPreviewCard';
+import Carousel from './Carousel';
+
+const CommunityPreview = () => {
+  const { posts, isLoading, isSuccess } = useFetchCommunityPost();
+
+  if (isLoading) {
+    return <div>커뮤니티 글을 가져오는 중입니다.</div>;
+  }
+  console.log('posts', posts);
+  if (!isSuccess) {
+    return <div> post데이터를 가져오는데 실패했습니다.</div>;
+  }
+
+  // chunk posts
+  const renderCard = post => {
+    return <CommunityPreviewCard post={post} key={post._id} />;
+  };
+
+  const renderCardWrapper = cards => {
+    return <div className="grid grid-cols-2 gap-10 ">{cards.map(card => card)}</div>;
+  };
+
+  // post -> <card /> -> [cardsWrapper, cardsWrapper]
+  const chunkpost = postlist => {
+    const cardlist = postlist.map(post => renderCard(post));
+    const chunkedCardList = [];
+    for (let i = 0; i < cardlist.length; i += 4) {
+      chunkedCardList.push(cardlist.slice(i, i + 4));
+    }
+    const wrappers = chunkedCardList.map(cards => renderCardWrapper(cards));
+    return wrappers;
+  };
+
+  // const carouselItems = chunkpost(posts);
+
+  return (
+    <div className="mb-100">
+      <h2 className="font-semibold text-24 text-gray-8">
+        최근에 올라온 <span className="text-primary-1">커뮤니티 글</span> 이에요
+      </h2>
+      <div>
+        <Link
+          to="/community"
+          className="flex justify-end font-bold text-15 text-sub-accent-2 mb-40"
+        >
+          더보기
+        </Link>
+      </div>
+
+      <Carousel slides={chunkpost(posts)} options={{ loop: true }} />
+    </div>
+  );
+};
+export default CommunityPreview;
+
+// [{},{}]

--- a/src/pages/Homepage/components/Community/preview-style.css
+++ b/src/pages/Homepage/components/Community/preview-style.css
@@ -1,0 +1,59 @@
+.community-embla {
+  /* max-width: 48rem; */
+  margin: auto;
+  --slide-height: 19rem;
+  --slide-spacing: 1rem;
+  --slide-size: 100%;
+}
+.community-embla__viewport {
+  overflow: hidden;
+}
+.community-embla__container {
+  display: flex;
+  touch-action: pan-y pinch-zoom;
+  margin-left: calc(var(--slide-spacing) * -1);
+}
+.community-embla__slide {
+  transform: translate3d(0, 0, 0);
+  flex: 0 0 var(--slide-size);
+  min-width: 0;
+  padding-left: var(--slide-spacing);
+}
+community-.embla__controls {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  justify-content: space-between;
+  gap: 1.2rem;
+  margin-top: 1.8rem;
+}
+.community-embla__buttons {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+  align-items: center;
+}
+.community-embla__button {
+  -webkit-tap-highlight-color: rgba(var(--text-high-contrast-rgb-value), 0.5);
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  touch-action: manipulation;
+  display: inline-flex;
+  text-decoration: none;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  box-shadow: inset 0 0 0 0.2rem var(--detail-medium-contrast);
+  width: 3.6rem;
+  height: 3.6rem;
+  z-index: 1;
+  border-radius: 50%;
+  color: var(--text-body);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.community-embla__button:disabled {
+  color: var(--detail-high-contrast);
+}

--- a/src/pages/Homepage/components/index.js
+++ b/src/pages/Homepage/components/index.js
@@ -1,3 +1,4 @@
 export { default as Hero } from './Hero';
 export { default as CarouselWrapper } from './Carousel/CarouselWrapper';
 export { default as PlanPreview } from './PlanPreview';
+export { default as CommunityPreview } from './Community';

--- a/src/pages/Homepage/index.jsx
+++ b/src/pages/Homepage/index.jsx
@@ -1,4 +1,4 @@
-import { Hero, CarouselWrapper, PlanPreview } from './components';
+import { Hero, CarouselWrapper, PlanPreview, CommunityPreview } from './components';
 
 const HomePage = () => {
   return (
@@ -7,6 +7,7 @@ const HomePage = () => {
       <CarouselWrapper />
       <PlanPreview />
       <div>다음 컴포넌트</div>
+      <CommunityPreview />
     </div>
   );
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

(#86) -> main

### 변경 사항

커뮤니티 페이지 글 미리보는 캐러셀 UI 구현했습니다.
### 🤔 need to check
피그마에는 더보기 버튼을 누르면 커뮤니티 페이지로 이동하는걸로 이해해서 그렇게 구현했는데요.

<img width="933" alt="스크린샷 2025-02-01 00 16 38" src="https://github.com/user-attachments/assets/0e285d19-8ea0-4fd5-914c-70bedc90be7c" />

뭔가 요 카드를 누르면 커뮤니티 게시글 상세보기로 이동해야 할것 같은 느낌이 듭니다. 그런데 현재 라우팅 경로에서는 /community페이지만 있어서 /comunity/:postId라던지 요렇게 상세보기 페이지 만으로 이동할 수 있는 방법이 없는것 같아요..!! 동현님도 마이페이지에서 비슷한 기능을 개발 중인걸로 아는데 어떤 방향으로 구현하고 계시나요?? @kdh990315 