### PR TITLE
[FEAT] : 토큰 인증 및 만료여부 판단하는 interceptor 로직 추가(#93)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,12 @@
 import './App.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './routes/router';
-import { Provider } from 'react-redux';
-import store from './redux/store';
-import { PersistGate } from 'redux-persist/integration/react';
-import { persistStore } from 'redux-persist';
-import { CookiesProvider } from 'react-cookie';
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-
-const queryClient = new QueryClient();
+import useAxiosInterceptor from '@/hooks/useAxiosInterceptor';
+import devAPI from '@/config/axiosDevConfig';
 
 function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={true} />
-      <Provider store={store}>
-        <PersistGate loading={null} persistor={persistStore(store)}>
-          <CookiesProvider>
-            <RouterProvider router={router} />
-          </CookiesProvider>
-        </PersistGate>
-      </Provider>
-    </QueryClientProvider>
-  );
+  useAxiosInterceptor(devAPI);
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/apis/postCreate.js
+++ b/src/apis/postCreate.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { serverURL } from './endpoints';
 import { getCookie } from '../utils/cookie';
-
+import devAPI from '../config/axiosDevConfig';
 export const createPost = async formData => {
   const token = getCookie('jwt');
 
@@ -10,7 +10,7 @@ export const createPost = async formData => {
   }
 
   try {
-    const response = await axios.post(`${serverURL}/posts/create`, formData, {
+    const response = await devAPI.post(`${serverURL}/posts/create`, formData, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'multipart/form-data',

--- a/src/components/common/Header/index.jsx
+++ b/src/components/common/Header/index.jsx
@@ -20,14 +20,14 @@ const Header = () => {
     etc: 'text-gray-7 ',
   };
 
-  const handleTripClick = (event) => {
+  const handleTripClick = event => {
     if (!userId) {
       event.preventDefault();
       Modal.warning({
         title: '로그인이 필요합니다.',
         content: '로그인하고 JejuMonth의 다양한 기능을 이용해 보세요.',
         onOk() {
-          navigate("/auth");
+          navigate('/auth');
         },
         okButtonProps: {
           style: {

--- a/src/config/axiosDevConfig.js
+++ b/src/config/axiosDevConfig.js
@@ -1,6 +1,5 @@
 const DEV_SERVER_URL = import.meta.env.VITE_API_BASE_URL;
 import axios from 'axios';
-import { getCookie } from '@/utils/cookie';
 
 const devAPI = axios.create({
   baseURL: DEV_SERVER_URL,
@@ -9,79 +8,5 @@ const devAPI = axios.create({
     'Content-Type': 'application/json',
   },
 });
-
-const onError = (status, message, errorDetail) => {
-  const error = { status, message, errorDetail };
-  throw error;
-};
-
-const onRequest = config => {
-  const jwt = getCookie('jwt');
-  if (jwt) {
-    config.headers.Authorization = `bearer ${jwt}`;
-  }
-  return config;
-};
-
-const onErrorRequest = error => {
-  return Promise.reject(error);
-};
-
-const onResponse = response => response;
-
-const onErrorResponse = error => {
-  if (axios.isAxiosError(error)) {
-    const originalRequest = error.config;
-    const { method, url } = originalRequest;
-    const { data: message, status: statusCode, statusText } = error.response;
-
-    // TODO : 배포 후 DEV상태에서만 로깅되도록 변경
-    console.log(
-      `[API] ${method.toUpperCase()} ${url} | ERROR ${statusCode} ${statusText} | ${message}`,
-    );
-
-    switch (statusCode) {
-      case 400: {
-        onError(statusCode, '잘못된 요청입니다.', message);
-        break;
-      }
-      case 401: {
-        onError(statusCode, '인증에 실패했습니다.', message);
-        break;
-      }
-      case 403: {
-        onError(statusCode, '권한이 없습니다.', message);
-        break;
-      }
-      case 404: {
-        onError(statusCode, '찾을 수 없는 페이지 입니다.', message);
-        break;
-      }
-      case 500: {
-        onError(statusCode, '서버 오류입니다.', message);
-        break;
-      }
-      default: {
-        onError(statusCode, '에러가 발생했습니다.', message);
-      }
-    }
-  } else if (error && error.name === 'TimeoutError') {
-    console.log(`[API] | Timeout ERROR ${error.toString()}`);
-    onError(0, '요청시간이 초과되었습니다.', '');
-  } else {
-    console.log(`[API] | ERROR ${error.toString()}`);
-    onError(0, '에러가 발생했습니다.', '');
-  }
-  return Promise.reject(error);
-};
-
-const setupInterCeptors = axiosInstance => {
-  axiosInstance.interceptors.request.use(onRequest, onErrorRequest);
-  axiosInstance.interceptors.response.use(onResponse, onErrorResponse);
-
-  return axiosInstance;
-};
-
-setupInterCeptors(devAPI);
 
 export default devAPI;

--- a/src/hooks/useAxiosInterceptor.js
+++ b/src/hooks/useAxiosInterceptor.js
@@ -1,0 +1,118 @@
+import { getCookie, removeCookie } from '@/utils/cookie';
+import { useDispatch } from 'react-redux';
+import { deleteUser } from '@/redux/slices/user.slice';
+import { useEffect } from 'react';
+import PATH from '@/constants/path';
+import axios from 'axios';
+
+// 사용처에서 instance에 devAPI 전달해주기
+const useAxiosInterceptor = instance => {
+  const dispatch = useDispatch();
+
+  const onRequest = config => {
+    const jwt = getCookie('jwt');
+    if (jwt) {
+      config.headers.Authorization = `bearer ${jwt}`;
+    }
+    return config;
+  };
+
+  const onErrorRequest = error => {
+    return Promise.reject(error);
+  };
+
+  const onError = (status, message, errorDetail) => {
+    const error = { status, message, errorDetail };
+    throw error;
+  };
+
+  const handle401Error = async originalRequest => {
+    // iat가 토큰 발급시간으로 사용되는 것이 맞다고 확인됨.
+    // 만료시간을 수동으로 확인한다.
+    // 1. 에러가 난 요청에 jwt가 있었는지 확인
+    const hasToken = originalRequest.headers['Authorization'].split(' ').at(1);
+    if (hasToken) {
+      // 있었으면 토큰 만료 오류로 판단. -> 쿠키와 유저 상태를 지우고 로그인 페이지로 이동
+      alert('사용자 정보가 만료되었습니다.홈으로 이동합니다.');
+      await dispatch(deleteUser());
+      removeCookie('jwt');
+      window.location.href = PATH.root;
+    } else {
+      // 없었으면 토큰 없이 요청보낸 것이므로 -> 로그인 페이지로 이동
+      alert('사용자 정보를 찾을 수 없습니다. 로그인 페이지로 이동합니다.');
+      await dispatch(deleteUser());
+      removeCookie('jwt');
+      window.location.href = PATH.auth;
+    }
+  };
+  const onResponse = response => response;
+
+  const onErrorResponse = error => {
+    if (axios.isAxiosError(error)) {
+      const originalRequest = error.config;
+      const { method, url } = originalRequest;
+      const { data: message, status: statusCode, statusText } = error.response;
+
+      // TODO : 배포 후 DEV상태에서만 로깅되도록 변경
+      console.log(
+        `[API] ${method.toUpperCase()} ${url} | ERROR ${statusCode} ${statusText} | ${message}`,
+      );
+
+      switch (statusCode) {
+        case 400: {
+          onError(statusCode, '잘못된 요청입니다.', message);
+          break;
+        }
+        case 401: {
+          handle401Error(originalRequest);
+          break;
+        }
+        case 403: {
+          onError(statusCode, '권한이 없습니다.', message);
+          break;
+        }
+        case 404: {
+          onError(statusCode, '찾을 수 없는 페이지 입니다.', message);
+          break;
+        }
+        case 500: {
+          onError(statusCode, '서버 오류입니다.', message);
+          break;
+        }
+        default: {
+          onError(statusCode, '에러가 발생했습니다.', message);
+        }
+      }
+    } else if (error && error.name === 'TimeoutError') {
+      console.log(`[API] | Timeout ERROR ${error.toString()}`);
+      onError(0, '요청시간이 초과되었습니다.', '');
+    } else {
+      console.log(`[API] | ERROR ${error.toString()}`);
+      onError(0, '에러가 발생했습니다.', '');
+    }
+    return Promise.reject(error);
+  };
+
+  // interceptor 추가
+  const setupInterceptors = () => {
+    const requestInterceptor = instance.interceptors.request.use(onRequest, onErrorRequest);
+    const responseInterceptor = instance.interceptors.response.use(onResponse, onErrorResponse);
+
+    return { requestInterceptor, responseInterceptor };
+  };
+
+  // interceptor 제거
+  const ejectInterceptors = (requestInterceptor, responseInterceptor) => {
+    instance.interceptors.request.eject(requestInterceptor);
+    instance.interceptors.response.eject(responseInterceptor);
+  };
+
+  useEffect(() => {
+    const { requestInterceptor, responseInterceptor } = setupInterceptors();
+
+    return () => {
+      ejectInterceptors(requestInterceptor, responseInterceptor);
+    };
+  }, []);
+};
+export default useAxiosInterceptor;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,26 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
+import { Provider } from 'react-redux';
+import store from './redux/store';
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+import { CookiesProvider } from 'react-cookie';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
+const queryClient = new QueryClient();
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={true} />
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistStore(store)}>
+          <CookiesProvider>
+            <App />
+          </CookiesProvider>
+        </PersistGate>
+      </Provider>
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

(#93) @jjeongsu feature/refreshToken -> main

### 변경 사항

### ✅ exp 가 없는 토큰의 만료여부를 프론트에서 수동으로 판별하는 로직을 추가하였습니다.
1. iat가 만료시간이 맞는지 검사 : 확인 결과 JWT의 iat는 토큰의 발급시간을 의미합니다.
2. 서버에서 상태코드 401 을 반환할경우 요청의 토큰 여부에 따라 분기해서 처리합니다.
    - 토큰이 정상적으로 존재하는데 401에러일 경우 만료된 토큰, 혹은 유효하지 않은 토큰으로 판단하여, 유저상태를 초기화시키고 유저에게 경고창을 띄운뒤, 홈으로 리디렉션합니다.
    - 토큰이 없는데 401이면 로그인하지 않은 사용자가 보낸 요청이므로 경고창을 띄우고 로그인창으로 리디렉션 합니다.
 
### ✅ 기존에 axiosDevConfig파일에 정의햇던 interceptor를 커스텀 훅으로 분리하였습니다.
해당 내용은 이제 useAxiosInterceptor.js에서 확인할 수 있으며, 이전보다 다양한 axios instance의 API 요청과 응답을 반복적인 코드 없이 보다 간편하게 제어할 수 있습니다.
 
