### PR TITLE
[REFACTOR] 쿼리키, api endpoint 상수 객체로 분리

### DIFF
--- a/src/apis/channelApi.js
+++ b/src/apis/channelApi.js
@@ -1,8 +1,9 @@
 import devAPI from '../config/axiosDevConfig';
+import { CHANNEL } from './endpoints';
 
 export const fetchChannels = async () => {
   try {
-    const response = await devAPI.get('/channels');
+    const response = await devAPI.get(CHANNEL);
     return response.data;
   } catch (error) {
     console.error('Failed to fetch channels:', error);

--- a/src/apis/commentCreateApi.js
+++ b/src/apis/commentCreateApi.js
@@ -1,8 +1,11 @@
 import devAPI from '../config/axiosDevConfig';
+import { COMMENT } from './endpoints';
 
-export const commentCreateApi = async (postId, comment, token) => {
+// TODO(수관) : 해당 파일 명을 commentApi.js로 바꿔주세요. 사용처 import 경로도 수정.
+// TODO(수관) : 해당 함수 명을 createCommentApi로 변경해주세요
+export const commentCreateApi = async (postId, comment) => {
   try {
-    const response = await devAPI.post(`/comments/create`, {
+    const response = await devAPI.post(COMMENT.create, {
       postId,
       comment,
     });
@@ -15,13 +18,14 @@ export const commentCreateApi = async (postId, comment, token) => {
 
 export const deleteCommentApi = async commentId => {
   try {
-    const response = await devAPI.delete(`/comments/delete`, { id: commentId });
+    const response = await devAPI.delete(COMMENT.delete, { id: commentId });
     return response.data;
   } catch (error) {
     console.error('댓글 삭제 실패:', error.response?.data || error.message);
   }
 };
 
+// TODO (동현) : commentDeleteApi함수는 삭제해주세요. 기존 사용처에서는 deleteCommentApi를 사용해주세요
 export const commentDeleteApi = async commentID => {
   try {
     const response = await devAPI.delete(`/comments/delete`, { id: commentID });

--- a/src/apis/endpoints.js
+++ b/src/apis/endpoints.js
@@ -1,3 +1,27 @@
 export const serverURL = import.meta.env.VITE_API_BASE_URL;
 
-// TODO : api endpoint 객체로 관리
+/**
+# ======================#
+|         AUTH          |
+# ======================#
+*/
+
+export const AUTH = Object.freeze({
+  signup: '/signup',
+  login: '/login',
+  logout: '/logout',
+});
+
+/**
+# ======================#
+|         USER         |
+# ======================#
+*/
+
+export const USER = Object.freeze({
+  updateUser: '/settings/update-user',
+  updatePassword: '/settings/update-password',
+  updatePhoto: `${serverURL}/users/upload-photo`,
+  deleteUser: '/users/delete-user',
+  getUser: userId => `/users/${userId}`,
+});

--- a/src/apis/endpoints.js
+++ b/src/apis/endpoints.js
@@ -25,3 +25,58 @@ export const USER = Object.freeze({
   deleteUser: '/users/delete-user',
   getUser: userId => `/users/${userId}`,
 });
+
+/**
+# ======================#
+|        CHANNEL        |
+# ======================#
+*/
+
+export const CHANNEL = '/channels';
+
+/**
+# ======================#
+|        FOLLOW         |
+# ======================#
+*/
+
+export const FOLLOW = Object.freeze({
+  create: `/follow/create`,
+  delete: `/follow/delete`,
+});
+
+/**
+# ======================#
+|          LIKE         |
+# ======================#
+*/
+
+export const LIKE = Object.freeze({
+  create: '/likes/create',
+  delete: `/likes/delete`,
+});
+
+/**
+# ======================#
+|          POST         |
+# ======================#
+*/
+
+export const POST = Object.freeze({
+  getChannelPost: channelId => `/posts/channel/${channelId}`,
+  getAuthorPost: userId => `/posts/author/${userId}`,
+  delete: `/posts/delete`,
+  update: `${serverURL}/posts/update`,
+  create: `${serverURL}/posts/create`,
+});
+
+/**
+# ======================#
+|         COMMENT       |
+# ======================#
+*/
+
+export const COMMENT = Object.freeze({
+  create: `/comments/create`,
+  delte: `/comments/delete`,
+});

--- a/src/apis/followApi.js
+++ b/src/apis/followApi.js
@@ -1,23 +1,24 @@
 import devAPI from '../config/axiosDevConfig';
+import { FOLLOW } from './endpoints';
 
 export const followUser = async userId => {
   try {
-    const response = await devAPI.post(`/follow/create`, { userId });
+    const response = await devAPI.post(FOLLOW.create, { userId });
     return response.data;
   } catch (error) {
-    console.error("팔로우 요청 실패:", error);
+    console.error('팔로우 요청 실패:', error);
     throw error;
   }
 };
 
 export const unfollowUser = async userId => {
   try {
-    const response = await devAPI.delete(`/follow/delete`, {
-      data: { id: userId }, 
+    const response = await devAPI.delete(FOLLOW.delete, {
+      data: { id: userId },
     });
     return response.data;
   } catch (error) {
-    console.error("언팔로우 요청 실패:", error);
+    console.error('언팔로우 요청 실패:', error);
     throw error;
   }
 };

--- a/src/apis/getUserData.js
+++ b/src/apis/getUserData.js
@@ -1,8 +1,10 @@
 import devAPI from '../config/axiosDevConfig';
-
+import { POST } from './endpoints';
+// TODO(동현) : 해당 파일은 삭제되어야 합니다.
+// TODO(동현) : 해당 함수를 postAPI로 옮겨주세요.
 export const getUserPost = async userId => {
   try {
-    const response = await devAPI.get(`/posts/author/${userId}`);
+    const response = await devAPI.get(POST.getAuthorPost(userId));
 
     return response.data;
   } catch (error) {
@@ -11,6 +13,7 @@ export const getUserPost = async userId => {
   }
 };
 
+// TODO(동현) : 해당 함수는 삭제해주세요. 대신 userApi.js에 있는 getUserApi함수를 사용해주세요.
 export const getUserData = async userId => {
   try {
     const response = await devAPI.get(`/users/${userId}`);

--- a/src/apis/likesApi.js
+++ b/src/apis/likesApi.js
@@ -1,17 +1,18 @@
 import devAPI from '../config/axiosDevConfig';
+import { LIKE } from './endpoints';
 
 export const createLikesApi = async postId => {
   try {
-    const response = await devAPI.post(`/likes/create`, { postId });
+    const response = await devAPI.post(LIKE.create, { postId });
     return response.data;
   } catch (error) {
     console.error(error);
   }
 };
 
-export const deleteLikesApi = async (likeId, token) => {
+export const deleteLikesApi = async likeId => {
   try {
-    const response = await devAPI.delete(`/likes/delete`, { id: likeId });
+    const response = await devAPI.delete(LIKE.delete, { id: likeId });
     return response.data;
   } catch (error) {
     console.error(error);

--- a/src/apis/postApi.js
+++ b/src/apis/postApi.js
@@ -1,11 +1,11 @@
 import devAPI from '../config/axiosDevConfig';
 import axios from 'axios';
-import { serverURL } from './endpoints';
+import { serverURL, POST } from './endpoints';
 import { getCookie } from '../utils/cookie';
 
 export const getPostByChannelApi = async channelId => {
   try {
-    const response = await devAPI.get(`/posts/channel/${channelId}`);
+    const response = await devAPI.get(POST.getChannelPost(channelId));
     return response.data;
   } catch (error) {
     console.error('채널 게시글 가져오기 실패:', error);
@@ -15,7 +15,7 @@ export const getPostByChannelApi = async channelId => {
 
 export const getChannelNameByIdApi = async channelId => {
   try {
-    const response = await devAPI.get(`/posts/channel/${channelId}`);
+    const response = await devAPI.get(POST.getChannelPost(channelId));
 
     if (response.data.name) {
       return response.data.name;
@@ -30,7 +30,7 @@ export const getChannelNameByIdApi = async channelId => {
 
 export const deletePostApi = async contentID => {
   try {
-    const response = await devAPI.delete(`/posts/delete`, {
+    const response = await devAPI.delete(POST.delete, {
       data: { id: contentID },
     });
     return response.data;
@@ -43,7 +43,7 @@ export const deletePostApi = async contentID => {
 export const updatePostApi = async formData => {
   const token = getCookie('jwt');
   try {
-    const response = await axios.put(`${serverURL}/posts/update`, formData, {
+    const response = await axios.put(POST.update, formData, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'multipart/form-data',

--- a/src/apis/postCreate.js
+++ b/src/apis/postCreate.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
-import { serverURL } from './endpoints';
+import { POST } from './endpoints';
 import { getCookie } from '../utils/cookie';
 
+// TODO(수관) : 해당 파일 없애고 createPostApi로 이름 변경 후 postApi.js파일로 옮기기
 export const createPost = async formData => {
   const token = getCookie('jwt');
 
@@ -10,7 +11,7 @@ export const createPost = async formData => {
   }
 
   try {
-    const response = await axios.post(`${serverURL}/posts/create`, formData, {
+    const response = await axios.post(POST.create, formData, {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'multipart/form-data',

--- a/src/apis/userApi.js
+++ b/src/apis/userApi.js
@@ -1,12 +1,12 @@
-import devAPI from '../config/axiosDevConfig';
-import { serverURL } from './endpoints';
-import { getCookie } from '@/utils/cookie';
 import axios from 'axios';
+import devAPI from '../config/axiosDevConfig';
+import { AUTH, USER } from './endpoints';
+import { getCookie } from '@/utils/cookie';
 
 export const postSignupApi = async data => {
   const { email, password, nickname } = data;
   try {
-    const response = await devAPI.post('/signup', {
+    const response = await devAPI.post(AUTH.signup, {
       email,
       password,
       fullName: nickname,
@@ -21,7 +21,7 @@ export const postSignupApi = async data => {
 export const postSigninApi = async data => {
   const { email, password } = data;
   try {
-    const response = await devAPI.post('/login', {
+    const response = await devAPI.post(AUTH.login, {
       email,
       password,
     });
@@ -33,12 +33,10 @@ export const postSigninApi = async data => {
 };
 
 export const postProfileImage = async data => {
-  const url = `${serverURL}/users/upload-photo`;
-
   const jwt = getCookie('jwt');
   try {
     // 헤더 추가
-    const response = await axios.post(url, data, {
+    const response = await axios.post(USER.updatePhoto, data, {
       headers: {
         Authorization: `bearer ${jwt}`,
       },
@@ -52,7 +50,7 @@ export const postProfileImage = async data => {
 export const putUserPassword = async data => {
   const { password } = data;
   try {
-    const response = await devAPI.put('/settings/update-password', {
+    const response = await devAPI.put(USER.updatePassword, {
       password,
     });
     return response.data;
@@ -64,7 +62,7 @@ export const putUserPassword = async data => {
 export const putUserFullname = async data => {
   const { fullName } = data;
   try {
-    const response = await devAPI.put('/settings/update-user', {
+    const response = await devAPI.put(USER.updateUser, {
       fullName,
       userName: fullName,
     });
@@ -77,7 +75,7 @@ export const putUserFullname = async data => {
 
 export const deleteUserApi = async userId => {
   try {
-    const response = await devAPI.delete('/users/delete-user', {
+    const response = await devAPI.delete(USER.deleteUser, {
       id: userId,
     });
     return response.data;
@@ -88,7 +86,7 @@ export const deleteUserApi = async userId => {
 
 export const postLogoutUserApi = async () => {
   try {
-    const response = await devAPI.post('/logout');
+    const response = await devAPI.post(AUTH.logout);
 
     return response.data;
   } catch (error) {
@@ -99,7 +97,7 @@ export const postLogoutUserApi = async () => {
 // 유저정보 가져오기
 export const getUserApi = async userId => {
   try {
-    const response = await devAPI.get(`/users/${userId}`);
+    const response = await devAPI.get(USER.getUser(userId));
 
     return response.data;
   } catch (error) {
@@ -110,7 +108,7 @@ export const getUserApi = async userId => {
 // 팔로우 정보 가져오기
 export const getUserFollowersApi = async userId => {
   try {
-    const response = await devAPI.get(`/users/${userId}`);
+    const response = await devAPI.get(USER.getUser(userId));
     return {
       followers: response.data.followers || [],
       following: response.data.following || [],

--- a/src/constants/querykey.js
+++ b/src/constants/querykey.js
@@ -1,0 +1,38 @@
+const USER = {
+  detail: id => ['user', 'detail', { userId: id }],
+};
+
+const TRIP = {
+  list: userId => ['trip', 'list', { userId: userId }],
+  detail: tripId => ['trip', 'detail', { tripId: tripId }],
+};
+
+const PLAN = {
+  all: userId => ['plan', 'list', { userId: userId }],
+  list: (userId, tripId) => ['plan', 'list', { userId: userId, tripId: tripId }],
+  detail: tripId => ['plan', 'detail', { tripId: tripId }],
+};
+
+const CHANNEL = {
+  list: ['channel', 'list'],
+};
+
+const POST = {
+  attractionList: ['post', 'list', { category: 'attractions' }],
+};
+
+const PLACE = {
+  detail: contentId => ['jeju_place', 'detail', contentId],
+  list: (category, keyword) => ['jeju_place', 'list', { category: category, keyword: keyword }],
+};
+
+const QUERY_KEY = Object.freeze({
+  user: { ...USER },
+  trip: { ...TRIP },
+  plan: { ...PLAN },
+  channel: { ...CHANNEL },
+  post: { ...POST },
+  place: { ...PLACE },
+});
+
+export default QUERY_KEY;

--- a/src/hooks/react-query/useFetchAllTrips.js
+++ b/src/hooks/react-query/useFetchAllTrips.js
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getAllTripsApi } from '@/apis/supabaseApi';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchAllTrips = userId => {
   const { data: trips, isLoading: isLoadingTrips } = useQuery({
-    queryKey: ['trip', 'list', { userId: userId }],
+    queryKey: QUERY_KEY.trip.list(userId),
     queryFn: () => getAllTripsApi(userId),
   });
 

--- a/src/hooks/react-query/useFetchAllUserPlans.js
+++ b/src/hooks/react-query/useFetchAllUserPlans.js
@@ -1,17 +1,18 @@
 // 사용자의 모든 trip을 조회하여 모든 plans를 가져오는 훅
 import { useQuery } from '@tanstack/react-query';
 import { getPlanApi, getAllTripsApi } from '@/apis/supabaseApi';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchAllUserPlans = userId => {
   // 1. 유저가 가진 모든 trip을 조회
   const { data: trips, isLoading: isLoadingTrips } = useQuery({
-    queryKey: ['trip', 'list', { userId: userId }],
+    queryKey: QUERY_KEY.trip.list(userId),
     queryFn: () => getAllTripsApi(userId),
   });
 
   // 2. 모든 trip에 대해 plans를 조회
   const { data: planData, isLoading: isLoadingPlans } = useQuery({
-    queryKey: ['plan', 'list', { userId: userId }],
+    queryKey: QUERY_KEY.plan.all(userId),
     queryFn: () => {
       if (!trips) return [];
       return Promise.all(trips.map(trip => getPlanApi(userId, trip.trip_id)));

--- a/src/hooks/react-query/useFetchCommunityPost.js
+++ b/src/hooks/react-query/useFetchCommunityPost.js
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchChannels } from '@/apis/channelApi';
 import { getPostByChannelApi } from '@/apis/postApi';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchCommunityPost = () => {
   //1. 모든 채널 조회
   const { data: channels } = useQuery({
-    queryKey: ['channel', 'list'],
+    queryKey: QUERY_KEY.channel.list,
     queryFn: () => fetchChannels(),
   });
 
@@ -15,7 +16,7 @@ const useFetchCommunityPost = () => {
     isLoading,
     isSuccess,
   } = useQuery({
-    queryKey: ['post', 'list', { category: 'attractions' }],
+    queryKey: QUERY_KEY.post.attractionList,
     queryFn: () => {
       if (!channels) return [];
       const attractionId = channels[0]['_id'];

--- a/src/hooks/react-query/useFetchPlace.js
+++ b/src/hooks/react-query/useFetchPlace.js
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getPlaceByExplanationApi } from '@/apis/visitJejuApi';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchPlace = contentId => {
   const { data: placeData, isLoading } = useQuery({
-    queryKey: ['jeju_place', 'detail', contentId],
+    queryKey: QUERY_KEY.place.detail(contentId),
     queryFn: () => getPlaceByExplanationApi(contentId),
   });
   return { placeData, isLoading };

--- a/src/hooks/react-query/useFetchPlansByTrip.js
+++ b/src/hooks/react-query/useFetchPlansByTrip.js
@@ -1,11 +1,12 @@
-import { getPlanApi } from '../../apis/supabaseApi';
+import { getPlanApi } from '@apis/supabaseApi';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@tanstack/react-query';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchPlansByTrip = tripId => {
   const userId = useSelector(state => state.user.userId);
   const { data: plans, isLoading: isLoadingPlan } = useQuery({
-    queryKey: ['plan', 'list', { userId: userId, tripId: tripId }],
+    queryKey: QUERY_KEY.plan.list(userId, tripId),
     queryFn: () => getPlanApi(userId, tripId),
   });
 

--- a/src/hooks/react-query/useFetchSearchedPlaceList.js
+++ b/src/hooks/react-query/useFetchSearchedPlaceList.js
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getPlaceBySearchApi } from '@/apis/visitJejuApi.js';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchSearchedPlaceList = (keyword, category) => {
   const { data: placeList, refetch } = useQuery({
-    queryKey: ['jeju_place', 'list', { category: category, keyword: keyword }],
+    queryKey: QUERY_KEY.place.list(category, keyword),
     queryFn: () => getPlaceBySearchApi(keyword, category),
   });
 

--- a/src/hooks/react-query/useFetchTrip.js
+++ b/src/hooks/react-query/useFetchTrip.js
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { getTripApi } from '@/apis/supabaseApi.js';
 import { useSelector } from 'react-redux';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchTrip = tripId => {
   const userId = useSelector(state => state.user.userId);
   const { data: trip, isLoading } = useQuery({
-    queryKey: ['trip', 'detail', tripId],
+    queryKey: QUERY_KEY.trip.detail(tripId),
     queryFn: () => getTripApi(userId, tripId),
   });
 

--- a/src/hooks/react-query/useFetchUser.js
+++ b/src/hooks/react-query/useFetchUser.js
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUserApi } from '@/apis/userApi';
+import QUERY_KEY from '@/constants/querykey';
 
 const useFetchUser = userId => {
   return useQuery({
-    //* user 정보 수정하는 곳에서도 같은 쿼리키로 관리되어야 함
-    queryKey: ['user', 'detail', { userId }],
+    queryKey: QUERY_KEY.user.detail(userId),
     queryFn: () => getUserApi(userId),
   });
 };

--- a/src/hooks/react-query/useMutateUser.js
+++ b/src/hooks/react-query/useMutateUser.js
@@ -1,5 +1,6 @@
 import { putUserFullname, putUserPassword, postProfileImage } from '@/apis/userApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import QUERY_KEY from '@/constants/querykey';
 
 export const useMutateUser = userId => {
   const queryClient = useQueryClient();
@@ -9,7 +10,7 @@ export const useMutateUser = userId => {
     onSuccess: async () => {
       console.log('성공적으로 이름을 변경하였습니다.');
       await queryClient.invalidateQueries({
-        queryKey: ['user', 'detail', { userId }],
+        queryKey: QUERY_KEY.user.detail(userId),
       });
     },
   });
@@ -19,7 +20,7 @@ export const useMutateUser = userId => {
     onSuccess: async () => {
       console.log('성공적으로 비밀번호를 변경하였습니다.');
       await queryClient.invalidateQueries({
-        queryKey: ['user', 'detail', { userId }],
+        queryKey: QUERY_KEY.user.detail(userId),
       });
     },
   });
@@ -29,7 +30,7 @@ export const useMutateUser = userId => {
     onSuccess: async () => {
       console.log('성공적으로 프로필 사진을 변경하였습니다.');
       await queryClient.invalidateQueries({
-        queryKey: ['user', 'detail', { userId }],
+        queryKey: QUERY_KEY.user.detail(userId),
       });
     },
   });

--- a/src/hooks/react-query/usePostPlan.js
+++ b/src/hooks/react-query/usePostPlan.js
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postPlanApi } from '@/apis/supabaseApi.js';
 import { useNavigate } from 'react-router';
+import QUERY_KEY from '@/constants/querykey';
 
 const usePostPlan = tripId => {
   const navigate = useNavigate();
@@ -10,7 +11,7 @@ const usePostPlan = tripId => {
     onSuccess: async () => {
       console.log('성공적으로 plan 데이터를 보냈습니다.');
       await queryClient.invalidateQueries({
-        queryKey: ['plan', 'detail', tripId],
+        queryKey: QUERY_KEY.plan.detail(tripId),
       });
       // mytrip으로 이동
       navigate(`/trip/my?trip_id=${tripId}`);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 코드 리팩토링

### 반영 브랜치

(#93 ) refactor-> main

### 변경 사항

#### REACT_QUERY 쿼리키 구조화하고, 쿼리키를 객체로 관리하도록 변경하였습니다.
-  쿼리키 객체 예시)
![image](https://github.com/user-attachments/assets/43ae3434-f2c2-4b36-b663-0208a7233739)

#### api end point들을 하드코딩하지 않고 상수화하여 관리하도록 변경하였습니다.
-  end point 객체 예시) 
![image](https://github.com/user-attachments/assets/d36bee24-22b0-4141-967d-503b2941569b)

#### @kdh990315 @Sugwan-p 님이 추가적으로 리팩토링 진행해주셔야 하는 부분은 주석으로 달아주었습니다. 확인 바랍니다.
- 주석 예시)
![image](https://github.com/user-attachments/assets/7cef7133-743f-4d10-8a91-2e84d597689c)

